### PR TITLE
[DXP-2139] keep original namespace metrics label in kaap PodMonitor

### DIFF
--- a/modules/monitoring-kaap-pod-monitor/config/kaap-bookkeeper-pod-monitor.yaml
+++ b/modules/monitoring-kaap-pod-monitor/config/kaap-bookkeeper-pod-monitor.yaml
@@ -29,6 +29,8 @@ spec:
       interval: "10s"
       scrapeTimeout: "10s"
       relabelings:
+        - action: labeldrop
+          regex: namespace
         - action: labelmap
           regex: __meta_kubernetes_pod_label_(.+)
         - sourceLabels: [__meta_kubernetes_namespace]

--- a/modules/monitoring-kaap-pod-monitor/config/kaap-broker-pod-monitor.yaml
+++ b/modules/monitoring-kaap-pod-monitor/config/kaap-broker-pod-monitor.yaml
@@ -28,6 +28,8 @@ spec:
       interval: "10s"
       scrapeTimeout: "10s"
       relabelings:
+        - action: labeldrop
+          regex: namespace
         - action: labelmap
           regex: __meta_kubernetes_pod_label_(.+)
         - sourceLabels: [__meta_kubernetes_namespace]

--- a/modules/monitoring-kaap-pod-monitor/config/kaap-proxy-pod-monitor.yaml
+++ b/modules/monitoring-kaap-pod-monitor/config/kaap-proxy-pod-monitor.yaml
@@ -28,6 +28,8 @@ spec:
       interval: "10s"
       scrapeTimeout: "10s"
       relabelings:
+        - action: labeldrop
+          regex: namespace
         - action: labelmap
           regex: __meta_kubernetes_pod_label_(.+)
         - sourceLabels: [__meta_kubernetes_namespace]


### PR DESCRIPTION
## 📋 Type of the Changes

- [ ] Breaking change
- [ ] Non-breaking change
- [x] Bug fix / minor change

## 🛠 Changes being made

* keep original namespace metrics label in kaap PodMonitor

## ✅ Checklist

- [ ] My code follows the code standards of this project
- [ ] Changed code is covered with unit tests
- [ ] I have updated READMEs and java docs (if applicable)
